### PR TITLE
fix(build): add syscall validation before creating profile

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -58,7 +58,9 @@ var buildCmd = &cobra.Command{
 			scanner := bufio.NewScanner(file)
 			for scanner.Scan() {
 				syscall := scanner.Text()
-				syscallList[string(syscall)]++
+				if seccomp.IsValidSyscall(syscall) {
+					syscallList[string(syscall)]++
+				}
 			}
 		}
 

--- a/internal/seccomputils/syscalls.go
+++ b/internal/seccomputils/syscalls.go
@@ -1,4 +1,4 @@
-package syscalls
+package seccomputils
 
 import (
 	"fmt"
@@ -20,4 +20,11 @@ func Print(writer io.Writer, syscalls []uint32) error {
 		fmt.Fprintln(writer, syscall)
 	}
 	return nil
+}
+
+// IsValidSyscall returns true if a valid system call was passed to the function.
+// Returns false otherwise.
+func IsValidSyscall(syscall string) bool {
+	_, err := seccomp.GetSyscallFromName(syscall)
+	return err == nil
 }

--- a/internal/seccomputils/syscalls_test.go
+++ b/internal/seccomputils/syscalls_test.go
@@ -1,4 +1,4 @@
-package syscalls
+package seccomputils
 
 import (
 	"bytes"
@@ -42,6 +42,39 @@ func TestPrint(t *testing.T) {
 			}
 			if gotWriter := writer.String(); gotWriter != tt.wantWriter {
 				t.Errorf("Print() = %v, want %v", gotWriter, tt.wantWriter)
+			}
+		})
+	}
+}
+
+func TestIsValidSyscall(t *testing.T) {
+	type args struct {
+		syscall string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "syscall is valid",
+			args: args{
+				syscall: "openat",
+			},
+			want: true,
+		},
+		{
+			name: "syscall is not valid",
+			args: args{
+				syscall: "openatx",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsValidSyscall(tt.args.syscall); got != tt.want {
+				t.Errorf("IsValidSyscall() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/writer/write.go
+++ b/internal/writer/write.go
@@ -6,7 +6,7 @@ import (
 	"path"
 
 	"github.com/alegrey91/harpoon/internal/archiver"
-	syscallsw "github.com/alegrey91/harpoon/internal/syscallswriter"
+	seccomputils "github.com/alegrey91/harpoon/internal/seccomputils"
 )
 
 type WriteOptions struct {
@@ -32,10 +32,10 @@ func Write(syscalls []uint32, functionSymbol string, opts WriteOptions) error {
 			return fmt.Errorf("error setting permissions to %s: %v", file.Name(), err)
 		}
 		// write to file
-		errOut = syscallsw.Print(file, syscalls)
+		errOut = seccomputils.Print(file, syscalls)
 	} else {
 		// write to stdout
-		errOut = syscallsw.Print(os.Stdout, syscalls)
+		errOut = seccomputils.Print(os.Stdout, syscalls)
 	}
 	if errOut != nil {
 		return fmt.Errorf("error printing out system calls: %v", errOut)

--- a/internal/writer/write.go
+++ b/internal/writer/write.go
@@ -6,7 +6,7 @@ import (
 	"path"
 
 	"github.com/alegrey91/harpoon/internal/archiver"
-	seccomputils "github.com/alegrey91/harpoon/internal/seccomputils"
+	"github.com/alegrey91/harpoon/internal/seccomputils"
 )
 
 type WriteOptions struct {


### PR DESCRIPTION
Fix #22 
In this PR I've added a new function under the `internal/seccomputils/` package to validate the syscalls before adding the to the seccomp profile.
This is done because we could include even files not generated by `harpoon`, so to ensure all the syscalls we are going to add to the profile are valid, there's now a function that avoid putting garbage on that.
Additionally I moved the old package `internal/syscallwriter/` under `internal/seccomputils/` since their scopes are quite similar.