### PR TITLE
chore(cmd/analyze.go): remove unspupported flag from example

### DIFF
--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -40,7 +40,7 @@ var analyzeCmd = &cobra.Command{
 	Short: "Analyze infers the symbols of functions that are tested by unit-tests",
 	Long: `
 `,
-	Example: "  harpoon analyze --exclude vendor/ -s",
+	Example: "  harpoon analyze --exclude vendor/",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if exclude != "" {
 			excludedPaths = strings.Split(exclude, ",")


### PR DESCRIPTION
This PR removes an unspupported flag from example in the `analyze` command.