### PR TITLE
fix: panic occurring when the program execution fails

### DIFF
--- a/cmd/capture.go
+++ b/cmd/capture.go
@@ -50,6 +50,7 @@ by passing the function name symbol and the binary args.
 
 		opts := captor.CaptureOptions{
 			CommandOutput: commandOutput,
+			CommandError:  commandError,
 			LibbpfOutput:  libbpfOutput,
 			Interval:      dumpInterval,
 		}

--- a/internal/executor/exec.go
+++ b/internal/executor/exec.go
@@ -11,6 +11,8 @@ import (
 // The cmdOutput argument is used to print the command output.
 func Run(cmd []string, cmdOutput, cmdError bool, wg *sync.WaitGroup, outputCh, errorCh chan<- string) {
 	defer func() {
+		close(outputCh)
+		close(errorCh)
 		wg.Done()
 	}()
 
@@ -18,8 +20,10 @@ func Run(cmd []string, cmdOutput, cmdError bool, wg *sync.WaitGroup, outputCh, e
 	stdout, _ := command.StdoutPipe()
 	stderr, _ := command.StderrPipe()
 
-	//command.Wait()
-	command.Start()
+	if err := command.Start(); err != nil {
+		fmt.Printf("command execution error: %v\n", err)
+		return
+	}
 
 	go func() {
 		if cmdOutput {
@@ -43,8 +47,6 @@ func Run(cmd []string, cmdOutput, cmdError bool, wg *sync.WaitGroup, outputCh, e
 	}()
 
 	command.Wait()
-	close(outputCh)
-	close(errorCh)
 }
 
 func Build(packagePath, outputFile string) (string, error) {

--- a/internal/executor/exec.go
+++ b/internal/executor/exec.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"bufio"
 	"fmt"
+	"os"
 	"os/exec"
 	"sync"
 )
@@ -21,7 +22,7 @@ func Run(cmd []string, cmdOutput, cmdError bool, wg *sync.WaitGroup, outputCh, e
 	stderr, _ := command.StderrPipe()
 
 	if err := command.Start(); err != nil {
-		fmt.Printf("command execution error: %v\n", err)
+		fmt.Fprintf(os.Stderr, "command execution error: %v\n", err)
 		return
 	}
 

--- a/tests/integration.txtar
+++ b/tests/integration.txtar
@@ -6,12 +6,6 @@
 # move on the testcases directory
 cd testcases/example-app/
 
-# test it doesn't panic when the file is not executable
-exec chmod -x bin/example-app
-exec harpoon capture -e -c -f main.main -- ./bin/example-app
-stdout 'command execution error: fork/exec .* permission denied'
-exec chmod +x bin/example-app
-
 # test usage
 exec harpoon analyze -h
 stdout 'Usage:'
@@ -34,6 +28,12 @@ cmp profile.json expected-profile.json
 # test harpoon capture command
 exec harpoon capture -h
 stdout 'Usage:'
+
+# test it doesn't panic when the file is not executable
+exec chmod -x bin/example-app
+exec harpoon capture -e -c -f main.main -- ./bin/example-app
+stdout 'command execution error: fork/exec .* permission denied'
+exec chmod +x bin/example-app
 
 # setting up test application
 exists bin/example-app

--- a/tests/integration.txtar
+++ b/tests/integration.txtar
@@ -32,7 +32,7 @@ stdout 'Usage:'
 # test it doesn't panic when the file is not executable
 exec chmod -x bin/example-app
 exec harpoon capture -e -c -f main.main -- ./bin/example-app
-stdout 'command execution error: fork/exec .* permission denied'
+stderr 'command execution error: fork/exec .* permission denied'
 exec chmod +x bin/example-app
 
 # setting up test application

--- a/tests/integration.txtar
+++ b/tests/integration.txtar
@@ -6,6 +6,12 @@
 # move on the testcases directory
 cd testcases/example-app/
 
+# test it doesn't panic when the file is not executable
+exec chmod -x bin/example-app
+exec harpoon capture -e -c -f main.main -- ./bin/example-app
+stdout 'command execution error: fork/exec .* permission denied'
+exec chmod +x bin/example-app
+
 # test usage
 exec harpoon analyze -h
 stdout 'Usage:'


### PR DESCRIPTION
Closes #59 

Considerations:
- I've added an integration test, although I don't know how much value it adds.
- It is probably better to refactor the `executor.Run` function to take in a callback instead of channels, so a user can decide how to handle the stdout/stderr stuff without being forced to use channels. But it's out of scope, just some food for thought.

Questions:
- Should we keep the newly added integration test?
- Should we print the error raised by the exec command to `stderr`? 