### PR TITLE
fix: panic in `capture` command, when no arguments are passed

### DIFF
--- a/internal/ebpf/probesfacade/captor/capture.go
+++ b/internal/ebpf/probesfacade/captor/capture.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"sync"
@@ -51,6 +52,10 @@ type ebpfSetup struct {
 // to the ebpf program.
 // Returns the ebpfSetup struct in case of seccess, an error in case of failure.
 func InitProbes(functionSymbol string, cmdArgs []string, opts CaptureOptions) (*ebpfSetup, error) {
+	if len(cmdArgs) == 0 {
+		return nil, errors.New("error no arguments provided, at least 1 argument is required")
+	}
+
 	if !opts.LibbpfOutput {
 		// suppress libbpf log ouput
 		bpf.SetLoggerCbs(

--- a/tests/integration.txtar
+++ b/tests/integration.txtar
@@ -35,6 +35,10 @@ exec harpoon capture -e -c -f main.main -- ./bin/example-app
 stderr 'command execution error: fork/exec .* permission denied'
 exec chmod +x bin/example-app
 
+# test it doesn't panic when no arguments are provided
+! exec harpoon capture -e -c -f main.main
+stdout '.* error no arguments provided, at least 1 argument is required'
+
 # setting up test application
 exists bin/example-app
 # this must be done within the testscript environment


### PR DESCRIPTION
Closes #10 