### PR TITLE
fix: analyze and hunt commands

### DIFF
--- a/cmd/hunt.go
+++ b/cmd/hunt.go
@@ -61,9 +61,6 @@ var huntCmd = &cobra.Command{
 		//fmt.Println(analysisReport)
 
 		for _, symbolsOrigins := range analysisReport.SymbolsOrigins {
-			fmt.Println("test binary:", symbolsOrigins.TestBinaryPath)
-			fmt.Println("symbols:", symbolsOrigins.Symbols)
-
 			// command builder
 			var captureArgs []string
 			captureArgs = append(captureArgs, symbolsOrigins.TestBinaryPath)
@@ -79,16 +76,16 @@ var huntCmd = &cobra.Command{
 			}
 
 			for _, functionSymbol := range symbolsOrigins.Symbols {
-				fmt.Printf("[%s]\n", functionSymbol)
 				resultCh := make(chan []uint32)
 				errorCh := make(chan error)
 				ctx := context.Background()
 
+				fmt.Println("tracing: ", symbolsOrigins.TestBinaryPath)
+				fmt.Printf("attaching probe: %s\n", functionSymbol)
 				ebpf, err := captor.InitProbes(functionSymbol, captureArgs, envVars, opts)
 				if err != nil {
 					return fmt.Errorf("error setting up ebpf module: %w", err)
 				}
-				defer ebpf.Close()
 
 				// this will get incremental results
 				go func() {
@@ -112,6 +109,7 @@ var huntCmd = &cobra.Command{
 					// the hunting.
 					break
 				}
+				ebpf.Close()
 			}
 		}
 		return nil

--- a/internal/analyzer/analyze.go
+++ b/internal/analyzer/analyze.go
@@ -68,10 +68,13 @@ func GetModuleName(goModFile *os.File) (string, error) {
 }
 
 func CheckFunctionExists(functionName string, goFile *os.File) (bool, error) {
+	searchString := functionName + "("
+
 	scanner := bufio.NewScanner(goFile)
+
 	for scanner.Scan() {
-		line := scanner.Text()
-		if strings.Contains(line, "func "+functionName) {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.Contains(line, searchString) {
 			return true, nil
 		}
 	}
@@ -80,4 +83,15 @@ func CheckFunctionExists(functionName string, goFile *os.File) (bool, error) {
 		return false, fmt.Errorf("error reading %s: %v", goFile.Name(), err)
 	}
 	return false, fmt.Errorf("unable to find function \"%s\" in %s file", functionName, goFile.Name())
+}
+
+// ExtractFunctionName extracts the function name from the given string.
+func ExtractFunctionName(path string) string {
+	// Split the string by the '.' character
+	parts := strings.Split(path, ".")
+	if len(parts) == 0 {
+		return ""
+	}
+	// Return the last part of the split result
+	return parts[len(parts)-1]
 }

--- a/internal/ebpf/probesfacade/captor/capture.go
+++ b/internal/ebpf/probesfacade/captor/capture.go
@@ -38,7 +38,7 @@ type CaptureOptions struct {
 	Interval      int
 }
 
-type ebpfSetup struct {
+type EbpfSetup struct {
 	mod      *bpf.Module
 	link     *bpf.BPFLink
 	pb       *bpf.PerfBuffer
@@ -52,7 +52,7 @@ type ebpfSetup struct {
 // InitProbes setup the ebpf module attaching probes and tracepoints
 // to the ebpf program.
 // Returns the ebpfSetup struct in case of seccess, an error in case of failure.
-func InitProbes(functionSymbol string, cmdArgs []string, env []string, opts CaptureOptions) (*ebpfSetup, error) {
+func InitProbes(functionSymbol string, cmdArgs []string, env []string, opts CaptureOptions) (*EbpfSetup, error) {
 	if len(cmdArgs) == 0 {
 		return nil, errors.New("error no arguments provided, at least 1 argument is required")
 	}
@@ -131,7 +131,7 @@ func InitProbes(functionSymbol string, cmdArgs []string, env []string, opts Capt
 		return nil, fmt.Errorf("error initializing map (%s) with PerfBuffer: %v", bpfEventsMap, err)
 	}
 
-	return &ebpfSetup{
+	return &EbpfSetup{
 		mod:      bpfModule,
 		link:     traceLink,
 		pb:       pb,
@@ -144,7 +144,7 @@ func InitProbes(functionSymbol string, cmdArgs []string, env []string, opts Capt
 }
 
 // Close closes the ebpf link and module.
-func (ebpf *ebpfSetup) Close() {
+func (ebpf *EbpfSetup) Close() {
 	ebpf.link.Destroy()
 	ebpf.mod.Close()
 }
@@ -152,7 +152,7 @@ func (ebpf *ebpfSetup) Close() {
 // Capture collects syscalls from the executed command.
 // Returns values through the given channels.
 // When the interval is 0, automatically closes the channels.
-func (ebpf *ebpfSetup) Capture(ctx context.Context, resultCh chan []uint32, errorCh chan error) {
+func (ebpf *EbpfSetup) Capture(ctx context.Context, resultCh chan []uint32, errorCh chan error) {
 	// setting up ticker to dump results
 	// every interval of time.
 	var ticker *time.Ticker

--- a/internal/elfreader/symbols.go
+++ b/internal/elfreader/symbols.go
@@ -1,0 +1,76 @@
+package elfreader
+
+import (
+	"debug/elf"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+type ElfReader struct {
+	file *elf.File
+}
+
+// NewElfReader opens an ELF file and returns the ElfReader struct.
+func NewElfReader(filePath string) *ElfReader {
+	elfFile, err := elf.Open(filePath)
+	if err != nil {
+		fmt.Println("error: %w", err)
+	}
+	return &ElfReader{
+		file: elfFile,
+	}
+}
+
+// Close closes the ElfReader file.
+func (e *ElfReader) Close() {
+	e.file.Close()
+}
+
+// FunctionSymbols returns the list of function symbols within the ELF file.
+func (e *ElfReader) FunctionSymbols(pattern string) ([]string, error) {
+	symbols, err := e.file.Symbols()
+	if err != nil {
+		return nil, fmt.Errorf("error getting symbols: %v", err)
+	}
+
+	var symbolsList []string
+	for _, symb := range symbols {
+		// filter only function symbols
+		if !(elf.ST_TYPE(symb.Info) == elf.STT_FUNC) {
+			continue
+		}
+		// filter for package related symbols
+		if !strings.Contains(symb.Name, pattern) {
+			continue
+		}
+		// filter out Test functions
+		if isTestFunction(symb.Name) {
+			continue
+		}
+		// filter out goroutines
+		if isGoroutine(symb.Name) {
+			continue
+		}
+		// filter out type struct
+		if strings.HasPrefix(symb.Name, "type:") {
+			continue
+		}
+		symbolsList = append(symbolsList, symb.Name)
+	}
+	return symbolsList, nil
+}
+
+// isGoroutine detects if the symbol passed as argument is a goroutine function.
+func isGoroutine(s string) bool {
+	// Regular expression to match ".func" followed by one or more digits
+	re := regexp.MustCompile(`\.func\d+$`)
+	return re.MatchString(s)
+}
+
+// isTestFunction detects if the symbol passed as argument is a Test function.
+func isTestFunction(s string) bool {
+	// Regular expression to check for valid Test suffix patterns
+	re := regexp.MustCompile(`\.Test[\w.]*$`)
+	return re.MatchString(s)
+}

--- a/tests/integration.txtar
+++ b/tests/integration.txtar
@@ -105,7 +105,7 @@ cmp profile.json expected-profile.json
 -- testcases/example-app/harpoon-expected-report.yml --
 ---
 symbolsOrigins:
-  - testBinaryPath: /tmp/results/randomic.test
+  - testBinaryPath: /tmp/results/__pkg_randomic.test
     symbols:
     - github.com/alegrey91/seccomp-test-coverage/pkg/randomic.RockPaperScissors
     - github.com/alegrey91/seccomp-test-coverage/pkg/randomic.ThrowDice


### PR DESCRIPTION
This PR fixes a bug that was present in the `analyze` command.
I actually changed the logic that is now reported here:
* walk the project file systems to find occurrences of `_test.go` files.
* when we find a `_test.go` file, we build the entire test of the package where we found the test.
* once built, we read the content of the test file to extract the symbols of the functions present in the binary.
* with all the collected symbols, we verify the presence of their associated function within the `_test.go` files in the same directory.
* if some function is found, then we add this to the final report.